### PR TITLE
60 auc estimation streamline conc scale for estimation add argument

### DIFF
--- a/R/concRespCore.R
+++ b/R/concRespCore.R
@@ -34,7 +34,9 @@
 #'   than 1/10th of the lowest concentration tested.
 #' @param bmd_up_bnd Multiplier for the bmd upper bound.  A value of 10 would require the bmd to be no lower
 #'   than 10 times the highest concentration tested.
-#' @param AUC If TRUE, generate and return Area under the curve (AUC) for the winning model after hit-calling. Defaults to TRUE.
+#' @param AUC Logical argument, defaults to FALSE. If TRUE, generate and return Area under the curve (AUC)
+#' for the winning model after hit-calling.
+#' @param ... Optional arguments for AUC estimation.
 #'
 #'
 #' @export
@@ -67,7 +69,7 @@ concRespCore <- function(row,
                          bmr_scale = 1.349,
                          bmd_low_bnd = NULL,
                          bmd_up_bnd = NULL,
-                         AUC = TRUE) {
+                         AUC = FALSE, ...) {
   # variable binding to pass cmd checks
   bmed <- cutoff <- onesd <- NULL
   # row needs to include cutoff and bmed
@@ -92,7 +94,7 @@ concRespCore <- function(row,
   summary <- tcplhit2_core(params, conc, resp, cutoff, onesd, bmr_scale, bmed, conthits, aicc, identifiers,bmd_low_bnd, bmd_up_bnd)
 
   if (AUC) {
-    summary["AUC"] <- post_hit_AUC(summary)
+    summary["AUC"] <- post_hit_AUC(summary, ...)
   }
 
   if (return.details) {

--- a/R/get_AUC.R
+++ b/R/get_AUC.R
@@ -19,6 +19,9 @@
 #' @param ps Numeric vector (or list) of model parameters for the specified model in `fit_method`.
 #' @param return.abs Logical argument, defaults to FALSE.
 #' If set to TRUE, the function will convert the negative AUC value and return a positive AUC.
+#' @param use.log Logical argument, defaults to FALSE. By default, the function estimates AUC with
+#' concentrations in normal unit. If set to TRUE, will use concentration in log10-scale for
+#' estimating AUC.
 #'
 #' @return AUC value (numeric)
 #'
@@ -32,38 +35,36 @@
 #'                 la = 4288.993, q = 5.770, er = -3.295)
 #' get_AUC("exp2", min(conc), max(conc), ps = modpars)
 #'
-get_AUC <- function(fit_method, lower, upper, ps, return.abs = FALSE) {
+get_AUC <- function(fit_method, lower, upper, ps, return.abs = FALSE, use.log = FALSE) {
 
-  # special cases - models in log scale, hill and gnls
-  if (fit_method %in% c("hill", "gnls")) {
-
-    # convert concentration to log scale
+  if (use.log) {
+    message("log10-scale concentration is used for AUC estimation")
+    # convert concentration to log10 scale
     lower <- log10(lower)
     upper <- log10(upper)
 
-    if (fit_method == "hill") {
-
-      # convert parameter to log scale
-      # paste log to the fname
-      ps["ga"] <- log10(ps[["ga"]])
-      fit_method <- paste0("log", fit_method)
-
-    } else if (fit_method == "gnls") {
-
-      # convert parameter to log scale
-      # paste log to the fname
-      ps["ga"] <- log10(ps[["ga"]])
-      ps["la"] <- log10(ps[["la"]])
-      fit_method <- paste0("log", fit_method)
+    # special cases - models that also need to convert parameters
+    if (fit_method %in% c("hill", "gnls", "exp4", "exp5")) {
+      if (fit_method == "gnls") {
+        ps["ga"] <- log10(ps[["ga"]])
+        ps["la"] <- log10(ps[["la"]])
+        } else {
+          # for loghill, logexp4 and logexp5
+          ps["ga"] <- log10(ps[["ga"]])
+        }
     }
+    # add "log" to the function name
+    fit_method <- paste0("log", fit_method)
+  } else {
+    # function name of hill in normal unit is "hillfn"
+    if (fit_method == "hill") {fit_method <- paste0(fit_method, "fn")}
   }
 
-  # calculate and return AUC
+  # calculate AUC value
   out <- integrate(get(fit_method),
                    lower,
                    upper,
                    ps = unlist(ps))
-
 
   if (return.abs) {
     return(abs(out$value))
@@ -71,5 +72,44 @@ get_AUC <- function(fit_method, lower, upper, ps, return.abs = FALSE) {
     return(out$value)
   }
 
+}
+
+# re-parameterization of functions other than hill and gnls with x on log10 scale
+
+logpoly1 <- function(ps, x) {
+  return(ps[1]*(10^x))
+}
+
+logexp2 = function(ps,x){
+  #a = ps[1], b = ps[2]
+  return(ps[1]*(exp((10^x)/ps[2]) - 1)  )
+}
+
+logexp3 = function(ps,x){
+  #a = ps[1], b = ps[2], p = ps[3]
+  return(ps[1]*(exp((10^x/ps[2])^ps[3]) - 1)  )
+}
+
+# for computational convenience, ga is also in log-10 scale
+logexp4 = function(ps,x){
+  # both x and ga are converted to log10-scale
+  #tp = ps[1], ga = ps[2]
+  return(ps[1]*(1-2^(-10^(x-ps[2])))  )
+}
+
+# for computational convenience, ga is also in log-10 scale
+logexp5 = function(ps,x){
+  #tp = ps[1], ga = ps[2], p = ps[3]
+  return(ps[1]*(1-2^(-10^((x-ps[2])*ps[3])))  )
+}
+
+logpoly2 <- function(ps, x) {
+  x0 = (10^x)/ps[2]
+  return(ps[1]*(x0 + x0*x0))
+}
+
+logpow = function(ps,x){
+  #a = ps[1], p = ps[2]
+  return(ps[1]*10^(x*ps[2])  )
 }
 

--- a/R/post_hit_AUC.R
+++ b/R/post_hit_AUC.R
@@ -8,7 +8,8 @@
 #' details, and pass these values to `get_AUC` to estimate the AUC for the
 #' winning model.
 #'
-#' @param hit_results output from `tcplhit2_core`
+#' @param hit_results output from `tcplhit2_core`.
+#' @param ... Optional arguments passed to get_AUC.
 #'
 #' @return AUC value of the winning model (numeric)
 #'


### PR DESCRIPTION
- added a new argument to get_AUC function allowing estimating AUC with concentration in log10-scale
- added re-parameterized functions for calculations in log scale (not exported)
- updated documentations of functions involve AUC calculation

Things that are nice to have from the ticket #60 : 
- Warming message is included. 
- "meta-data" on which concentration-scale is used for AUC estimation in output, didn't implement. Consider there might be situation when users want to use the function on multiple curves in a loop or with mapping like `apply()`, in my opinion it will make things easier if the function only return a single value. 