### PR TITLE
71 update the bmd lower boundary censoring code min conc = 0 for lower threshold

### DIFF
--- a/R/tcplhit2_core.R
+++ b/R/tcplhit2_core.R
@@ -179,7 +179,7 @@ tcplhit2_core <- function(params, conc, resp, cutoff, onesd,bmr_scale = 1.349, b
       if (bmd_low_bnd > 0 & bmd_low_bnd <= 1) {
         # warning message for extreme values
         if (bmd_low_bnd < 1e-3){warning("The specified bmd_lower_bnd is less than 1e-3. This may result in an extremely low threshold value for BMD censoring. Suggested value is 0.1.")}
-        min_conc <- min(conc)
+        min_conc <- min(conc[conc!=0])
         min_bmd <- min_conc*bmd_low_bnd
         if(bmd < min_bmd){
           bmd_diff <- min_bmd - bmd


### PR DESCRIPTION
Bug: BMD lower censoring threshold should be set based on the lowest experimental dose. However if the data being passed into tcplfit2_core and tcplhit2_core include the untreated control group (conc = 0), the BMD lower bound censoring is not working as intended because the current code min(conc) will return 0. 

- Updated the BMD censoring data such that if the data contain untreated control group (i.e. conc  = 0), BMD lower bond censoring will based on the lowest experimental concentration that is not 0. 
 - Added a unit test to ensure BMD censoring is working appropriately after the update. 