### PR TITLE
83 errfun should default to dt4 if not provided to tcplhit2 core

### DIFF
--- a/R/tcplhit2_core.R
+++ b/R/tcplhit2_core.R
@@ -80,7 +80,7 @@ tcplhit2_core <- function(params, conc, resp, cutoff, onesd,bmr_scale = 1.349, b
   # get error distribution
   errfun = params[["errfun"]]
   if (is.null(errfun))
-    warning("'errfun' is missing in the output from tcplfit2_core. 'errfun' tracks the error distribution assumed for the model fits and should be provided in 'params' list. -- see tcplfit2_core help for additional details.")
+    stop("'errfun' is missing in the output from tcplfit2_core. 'errfun' tracks the error distribution assumed for the model fits and should be provided in 'params' list. -- see tcplfit2_core help for additional details.")
 
   # get aics and degrees of freedom
   aics <- sapply(params$modelnames, function(x) {

--- a/R/tcplhit2_core.R
+++ b/R/tcplhit2_core.R
@@ -79,6 +79,8 @@ tcplhit2_core <- function(params, conc, resp, cutoff, onesd,bmr_scale = 1.349, b
 
   # get error distribution
   errfun = params[["errfun"]]
+  if (is.null(errfun))
+    warning("'errfun' is missing in the output from tcplfit2_core. 'errfun' tracks the error distribution assumed for the model fits and should be provided in 'params' list.")
 
   # get aics and degrees of freedom
   aics <- sapply(params$modelnames, function(x) {

--- a/R/tcplhit2_core.R
+++ b/R/tcplhit2_core.R
@@ -80,7 +80,7 @@ tcplhit2_core <- function(params, conc, resp, cutoff, onesd,bmr_scale = 1.349, b
   # get error distribution
   errfun = params[["errfun"]]
   if (is.null(errfun))
-    warning("'errfun' is missing in the output from tcplfit2_core. 'errfun' tracks the error distribution assumed for the model fits and should be provided in 'params' list.")
+    warning("'errfun' is missing in the output from tcplfit2_core. 'errfun' tracks the error distribution assumed for the model fits and should be provided in 'params' list. -- see tcplfit2_core help for additional details.")
 
   # get aics and degrees of freedom
   aics <- sapply(params$modelnames, function(x) {


### PR DESCRIPTION
'errfun' is required in `tcplhit2_core`. Adding a check for if this parameter is provided in `params` / output from `tcplfit2_core`. If the function should throw an error. 