### PR TITLE
changed sort(conc)[2] to sort(unique(conc))[2]

### DIFF
--- a/R/concRespPlot2.R
+++ b/R/concRespPlot2.R
@@ -37,7 +37,6 @@ concRespPlot2 <- function(row, log_conc = FALSE) {
     # less than the second lowest dose (in log).
     conc <- replace(conc, conc==-Inf, sort(unique(conc))[2]-1)
     conc_plot <- seq(from=min(conc),to=max(conc),length=100)
-    conc_plot <- replace(conc_plot, conc_plot==-Inf, sort(conc)[2]-1)
     # what will be passed into the object function to calculate responses for the curve
     calc.x <- 10**conc_plot
   } else {

--- a/R/concRespPlot2.R
+++ b/R/concRespPlot2.R
@@ -35,7 +35,7 @@ concRespPlot2 <- function(row, log_conc = FALSE) {
     conc <- log10(conc)
     # replace the negative infinity with a number that is one log-10 unit
     # less than the second lowest dose (in log).
-    conc <- replace(conc, conc==-Inf, sort(conc)[2]-1)
+    conc <- replace(conc, conc==-Inf, sort(unique(conc))[2]-1)
     conc_plot <- seq(from=min(conc),to=max(conc),length=100)
     conc_plot <- replace(conc_plot, conc_plot==-Inf, sort(conc)[2]-1)
     # what will be passed into the object function to calculate responses for the curve


### PR DESCRIPTION
Tested function by pulling from source file in branch of tcplFit2. Using the same code given in the reproducible error, the untreated control was reassigned to the value of -2 with the appropriate response of 0.01. Produces plot that includes the very first point at (-2,0.01). 

