### PR TITLE
redefined top as max absolute resp across conc range

### DIFF
--- a/R/hitcontinner.R
+++ b/R/hitcontinner.R
@@ -18,6 +18,8 @@
 #' @param errfun Which error distribution to assume for each point, defaults to
 #'   "dt4". "dt4" is the original 4 degrees of freedom t-distribution. Another
 #'   supported distribution is "dnorm", the normal distribution.
+#' @param poly2.biphasic Which fitting method to use for poly2. If poly2.biphasic = TRUE, allows for biphasic polynomial 2
+#'   model fits (i.e. both monotonic and non-monotonic). (Defaults to TRUE.)
 #'
 #' @importFrom stats pt
 #' @importFrom stats aggregate
@@ -64,7 +66,7 @@ hitcontinner = function(conc, resp, top, cutoff, er, ps, fit_method, caikwt, mll
   # P3 = pnorm((top-cutoff)/topsd) #odds of top above cutoff
   #assume ps may have nas in them
   ps = ps[!is.na(ps)]
-  P3 = toplikelihood(fname, cutoff, conc, resp, ps, top, mll, errfun = errfun) #odds of top above cutoff
+  P3 = toplikelihood(fname, cutoff, conc, resp, ps, top, mll, errfun = errfun, poly2.biphasic = poly2.biphasic) #odds of top above cutoff
 
   #multiply three probabilities
   return(P1*P2*P3)

--- a/R/hitcontinner.R
+++ b/R/hitcontinner.R
@@ -40,7 +40,7 @@
 #' hitcontinner(conc,resp,top,cutoff = 0.8, er,ps,fit_method, caikwt, mll)
 #' hitcontinner(conc,resp,top,cutoff = 1, er,ps,fit_method, caikwt, mll)
 #' hitcontinner(conc,resp,top,cutoff = 1.2, er,ps,fit_method, caikwt, mll)
-hitcontinner = function(conc, resp, top, cutoff, er, ps, fit_method, caikwt, mll, errfun = "dt4"){
+hitcontinner = function(conc, resp, top, cutoff, er, ps, fit_method, caikwt, mll, errfun = "dt4", poly2.biphasic = TRUE){
 
   #Each P represents the odds of the curve being a hit according to different criteria; multiply all Ps to get hit odds overall
   if(fit_method == "none") return(0)

--- a/R/tcplfit2_core.R
+++ b/R/tcplfit2_core.R
@@ -114,10 +114,10 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
           assign(model, append(get(model), list(ac50 = acy(.5 * get(model)$top, get(model), type = model))))
         } else if (model == "gnls") {
           # gnls methods; use calculated top/ac50, etc.
-          assign(model, append(get(model), list(top = acy(0, get(model), type = model, returntop = T))))
-          # find x_top and check if outside tested concentration range
-          x_top = acy(0, get(model), type = model, returntoploc = T)
-          if (x_top > max(conc)){
+          # before assigning to model, verify xtop is not outside conc range
+          top = acy(0, get(model), type = model, returntop = T)
+          x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
+          if (x_top > max(conc) | x_top < min(conc)){ #x_top outside tested conc range
             # replace untreated controls with psuedo-value
             if (any(conc == 0)) warning("Data contains untreated controls (conc = 0). A pseudo value replaces -Inf after log-transform.  The pseudo value is set to one log-unit below the lowest experimental `conc`.")
             logc_temp <- replace(logc, logc == -Inf, sort(unique(logc)[2]-1))
@@ -125,7 +125,11 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
             conc_seq <- 10**seq(from = min(logc_temp), to = max(logc_temp), length.out = 100)
             modpars <- get(model)[get(model)$pars]
             fit = do.call(model, list(unlist(modpars),conc_seq))
-            assign(model, append(get(model), list(top = fit[which.max(abs(fit))] )))
+            top = fit[which.max(abs(fit))]
+            x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
+            assign(model, append(get(model), list(top = top))) # assign empirical top
+          } else { #x_top within tested conc range
+            assign(model, append(get(model), list(top = top))) # assign analytical top
           }
           # check if the theoretical top was calculated
           if(is.na(get(model)$top)){

--- a/R/tcplfit2_core.R
+++ b/R/tcplfit2_core.R
@@ -115,6 +115,18 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
         } else if (model == "gnls") {
           # gnls methods; use calculated top/ac50, etc.
           assign(model, append(get(model), list(top = acy(0, get(model), type = model, returntop = T))))
+          # find x_top and check if outside tested concentration range
+          x_top = acy(0, get(model), type = model, returntoploc = T)
+          if (x_top > max(conc)){
+            # replace untreated controls with psuedo-value
+            if (any(conc == 0)) warning("Data contains untreated controls (conc = 0). A pseudo value replaces -Inf after log-transform.  The pseudo value is set to one log-unit below the lowest experimental `conc`.")
+            logc_temp <- replace(logc, logc == -Inf, sort(unique(logc)[2]-1))
+            # generate concentration sequence over entire experimental concentration range
+            conc_seq <- 10**seq(from = min(logc_temp), to = max(logc_temp), length.out = 100)
+            modpars <- get(model)[get(model)$pars]
+            fit = do.call(model, list(unlist(modpars),conc_seq))
+            assign(model, append(get(model), list(top = fit[which.max(abs(fit))] )))
+          }
           # check if the theoretical top was calculated
           if(is.na(get(model)$top)){
             # if the theoretical top is NA return NA for ac50 and ac50_loss

--- a/R/tcplfit2_core.R
+++ b/R/tcplfit2_core.R
@@ -96,14 +96,22 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
     }
 
       if (to.fit) {
-        if (model %in% c("poly1", "poly2", "pow", "exp2", "exp3")) {
-          # methods that grow without bound: top defined as model value at max conc
-          assign(model, append(get(model), list(top = get(model)$modl[which.max(abs(get(model)$modl))]))) # top is taken to be highest model value
+        if (!model %in% c("cnst","gnls")) {
+          # replace untreated controls with psuedo-value
+          if (any(conc == 0)) warning("Data contains untreated controls (conc = 0). A pseudo value replaces -Inf after log-transform.  The pseudo value is set to one log-unit below the lowest experimental `conc`.")
+          logc_temp <- replace(logc, logc == -Inf, sort(unique(logc)[2]-1))
+          # generate concentration sequence over entire experimental concentration range
+          conc_seq <- 10**seq(from = min(logc_temp), to = max(logc_temp), length.out = 100)
+          modpars <- get(model)[get(model)$pars]
+          # fit the curve across concentration sequence
+          if (model == "hill") {
+            fit = do.call("hillfn",list(unlist(modpars),conc_seq))
+          } else {
+            fit = do.call(model, list(unlist(modpars),conc_seq))
+          }
+          # top is taken to be the maximal absolute predicted value of the model within the tested concentration range
+          assign(model, append(get(model), list(top = fit[which.max(abs(fit))] )))
           assign(model, append(get(model), list(ac50 = acy(.5 * get(model)$top, get(model), type = model))))
-        } else if (model %in% c("hill", "exp4", "exp5")) {
-          # methods with a theoretical top/ac50
-          assign(model, append(get(model), list(top = get(model)$tp)))
-          assign(model, append(get(model), list(ac50 = get(model)$ga)))
         } else if (model == "gnls") {
           # gnls methods; use calculated top/ac50, etc.
           assign(model, append(get(model), list(top = acy(0, get(model), type = model, returntop = T))))

--- a/R/tcplhit2_core.R
+++ b/R/tcplhit2_core.R
@@ -145,7 +145,7 @@ tcplhit2_core <- function(params, conc, resp, cutoff, onesd,bmr_scale = 1.349, b
     mll <- length(modpars) - aics[[fit_method]] / 2
     hitcall <- hitcontinner(conc, resp, top, cutoff, er,
       ps = unlist(modpars), fit_method,
-      caikwt = caikwt, mll = mll, errfun = errfun
+      caikwt = caikwt, mll = mll, errfun = errfun, poly2.biphasic = poly2.biphasic
     )
   } else {
     hitcall <- hitloginner(conc, resp, top, cutoff, ac50)

--- a/R/toplikelihood.R
+++ b/R/toplikelihood.R
@@ -40,24 +40,44 @@ toplikelihood = function(fname, cutoff, conc, resp, ps, top, mll, errfun = "dt4"
 
   #reparameterize so that top is exactly at cutoff
   if(fname == "exp2"){
-    ps[1] = cutoff/( exp(max(conc)/ps[2]) - 1 )
+    x_top = acy(y = top, modpars = list(a=ps[1],b=ps[2],er=ps[3]),type=fname)
+    ps[1] = cutoff/( exp(x_top/ps[2]) - 1 )
   } else if(fname == "exp3"){
-    ps[1] = cutoff/( exp((max(conc)/ps[2])^ps[3]) - 1 )
+    x_top = acy(y = top, modpars = list(a=ps[1],b=ps[2],p=ps[3],er=ps[4]),type=fname)
+    ps[1] = cutoff/( exp((x_top/ps[2])^ps[3]) - 1 )
   } else if(fname == "exp4"){
-    ps[1] = cutoff
+    if (top == ps[1]) {
+      ps[1] = cutoff
+    } else {
+      x_top = acy(y = top, modpars = list(tp=ps[1],ga=ps[2],er=ps[3]),type=fname)
+      ps[1] = cutoff/( 1 - 2^(-x_top/ps[2]))
+    }
   } else if(fname == "exp5"){
-    ps[1] = cutoff
+    if (top == ps[1]) {
+      ps[1] = cutoff
+    } else{
+      x_top = acy(y = top, modpars = list(tp=ps[1], ga=ps[2], p=ps[3], er=ps[4]), type = fname)
+      ps[1]  = cutoff/ (1-2^(-(x_top/ps[2])^ps[3]))
+    }
   } else if(fname == "hillfn"){
-    ps[1] = cutoff
+    if (top == ps[1]){
+      ps[1] = cutoff
+    } else {
+      x_top = acy(y = top, modpars = list(tp=ps[1], ga=ps[2], p=ps[3], er=ps[4]), type = "hill")
+      ps[1] = cutoff * ( 1 + (ps[2]/x_top)^ps[3])
+    }
   } else if(fname == "gnls"){
-    #approximating actual top with theoretical top for convenience.
-    ps[1] = cutoff
+    x_top = acy(y = top, modpars = list(tp=ps[1],ga=ps[2],p=ps[3],la=ps[4],q=ps[5],er=ps[6]), type = fname)
+    ps[1] = cutoff * (( 1 + (ps[2]/x_top)^ps[3])*( 1 + (x_top/ps[4])^ps[5]))
   } else if(fname == "poly1"){
-    ps[1] = cutoff/max(conc)
+    x_top = acy(y = top, modpars = list(a=ps[1],er=ps[2]),type = fname)
+    ps[1] = cutoff/x_top
   } else if(fname == "poly2"){
-    ps[1] = cutoff/(max(conc)/ps[2] + (max(conc)/ps[2])^2 )
+    x_top = acy(y = top, modpars = list(a=ps[1], b=ps[2], er=ps[3]), type = fname, poly2.biphasic = poly2.biphasic)
+    ps[1] = cutoff/(x_top/ps[2] + (x_top/ps[2])^2 )
   } else if(fname == "pow"){
-    ps[1] = cutoff/(max(conc)^ps[2])
+    x_top = acy(y = top, modpars = list(a=ps[1], p=ps[2], er=ps[3]), type = fname)
+    ps[1] = cutoff/(x_top^ps[2])
   }
   #get loglikelihood of top exactly at cutoff, use likelihood profile test
   # to calculate probability of being above cutoff

--- a/R/toplikelihood.R
+++ b/R/toplikelihood.R
@@ -18,6 +18,8 @@
 #' @param errfun Which error distribution to assume for each point, defaults to
 #'   "dt4". "dt4" is the original 4 degrees of freedom t-distribution. Another
 #'   supported distribution is "dnorm", the normal distribution.
+#' @param poly2.biphasic Which fitting method to use for poly2. If poly2.biphasic = TRUE, allows for biphasic polynomial 2
+#'   model fits (i.e. both monotonic and non-monotonic). (Defaults to TRUE.)
 #'
 #' @importFrom stats pchisq
 #'
@@ -34,7 +36,7 @@
 #' toplikelihood(fname, cutoff = .8, conc, resp, ps, top, mll)
 #' toplikelihood(fname, cutoff = 1, conc, resp, ps, top, mll)
 #' toplikelihood(fname, cutoff = 1.2, conc, resp, ps, top, mll)
-toplikelihood = function(fname, cutoff, conc, resp, ps, top, mll, errfun = "dt4"){
+toplikelihood = function(fname, cutoff, conc, resp, ps, top, mll, errfun = "dt4", poly2.biphasic = TRUE){
   #cutoff needs to account for sign otherwise reparameterization will flip the model
   cutoff = cutoff*sign(top)
 


### PR DESCRIPTION
I implemented changes with how top is defined in tcplfit2_core functionality. I did not change anything in tcplhit2_core functionality including the hitcalling process. Hitcalling changes will be made in a separate PR. 

I redefined top as detailed in the ticket. However, I am finding this top value graphically for all the methods except gain-loss which already uses the derivative and sets it equal to 0 to find the model top. Because of this method, I implemented a pseudo-value transformation for untreated control groups (conc = 0) so that conc_seq can successfully generate points along the range. 

I have a generated html tester file available upon request. 

01/30/25 EDIT: Hitcalling changes have been pushed to this PR. Functionality includes the correct top redefinition in `tcplfit2_core()` AND correct P3 calculation in `toplikelihood()` that's used during hitcalling process. Correct P3 calculation requires the passing of the `poly2.biphasic` parameter from `tcplhit2_core()` into `hitcontinner()` and `toplikelihood()`. 

