### PR TITLE
124 acy returning na for gnls example

### DIFF
--- a/R/tcplfit2_core.R
+++ b/R/tcplfit2_core.R
@@ -117,7 +117,7 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
           # before assigning to model, verify xtop is not outside conc range
           top = acy(0, get(model), type = model, returntop = T)
           x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
-          if (x_top > max(conc) | x_top < min(conc) | is.na(x_top)){ #x_top outside tested conc range
+          if (x_top > max(conc) | x_top < min(conc) | is.na(x_top)){ #x_top outside tested conc range or is NA
             # replace untreated controls with psuedo-value
             if (any(conc == 0)) warning("Data contains untreated controls (conc = 0). A pseudo value replaces -Inf after log-transform.  The pseudo value is set to one log-unit below the lowest experimental `conc`.")
             logc_temp <- replace(logc, logc == -Inf, sort(unique(logc)[2]-1))
@@ -126,7 +126,6 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
             modpars <- get(model)[get(model)$pars]
             fit = do.call(model, list(unlist(modpars),conc_seq))
             top = fit[which.max(abs(fit))]
-            # x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
             assign(model, append(get(model), list(top = top))) # assign empirical top
           } else { #x_top within tested conc range
             assign(model, append(get(model), list(top = top))) # assign analytical top

--- a/R/tcplfit2_core.R
+++ b/R/tcplfit2_core.R
@@ -117,7 +117,7 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
           # before assigning to model, verify xtop is not outside conc range
           top = acy(0, get(model), type = model, returntop = T)
           x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
-          if (x_top > max(conc) | x_top < min(conc)){ #x_top outside tested conc range
+          if (x_top > max(conc) | x_top < min(conc) | is.na(x_top)){ #x_top outside tested conc range
             # replace untreated controls with psuedo-value
             if (any(conc == 0)) warning("Data contains untreated controls (conc = 0). A pseudo value replaces -Inf after log-transform.  The pseudo value is set to one log-unit below the lowest experimental `conc`.")
             logc_temp <- replace(logc, logc == -Inf, sort(unique(logc)[2]-1))
@@ -126,7 +126,7 @@ tcplfit2_core <- function(conc, resp, cutoff, force.fit = FALSE, bidirectional =
             modpars <- get(model)[get(model)$pars]
             fit = do.call(model, list(unlist(modpars),conc_seq))
             top = fit[which.max(abs(fit))]
-            x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
+            # x_top = acy(y = top, modpars = get(model), type = model, verbose = verbose)
             assign(model, append(get(model), list(top = top))) # assign empirical top
           } else { #x_top within tested conc range
             assign(model, append(get(model), list(top = top))) # assign analytical top

--- a/R/toplikelihood.R
+++ b/R/toplikelihood.R
@@ -69,8 +69,12 @@ toplikelihood = function(fname, cutoff, conc, resp, ps, top, mll, errfun = "dt4"
       ps[1] = cutoff * ( 1 + (ps[2]/x_top)^ps[3])
     }
   } else if(fname == "gnls"){
-    x_top = acy(y = top, modpars = list(tp=ps[1],ga=ps[2],p=ps[3],la=ps[4],q=ps[5],er=ps[6]), type = fname)
-    ps[1] = cutoff * (( 1 + (ps[2]/x_top)^ps[3])*( 1 + (x_top/ps[4])^ps[5]))
+    if (top == ps[1]) {
+      ps[1] = cutoff
+    } else {
+      x_top = acy(y = top, modpars = list(tp=ps[1],ga=ps[2],p=ps[3],la=ps[4],q=ps[5],er=ps[6]), type = fname)
+      ps[1] = cutoff * (( 1 + (ps[2]/x_top)^ps[3])*( 1 + (x_top/ps[4])^ps[5]))
+    }
   } else if(fname == "poly1"){
     x_top = acy(y = top, modpars = list(a=ps[1],er=ps[2]),type = fname)
     ps[1] = cutoff/x_top


### PR DESCRIPTION
Updated code includes additional checks for gnls when top == tp and x_top is NA. 

- top will be found empirically in `tcplfit2_core`
- cutoff is assigned to re-scaled tp parameter in `toplikelihood` during calculation of P3. This is similar to behavior for other models with tp parameter. 